### PR TITLE
AM_CONFIG_HEADER is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# Upslug2
+
+**Note:** this repository is a fork from [wspringer](https://github.com/wspringer/upslug2)
+
+I made only a _very_ [little fix](https://github.com/carlesso/upslug2/commit/e3d1163d130e588f91c863b2719018cab7470e38)
+to be able to compile nowdays.
+
+**ALL** credit goes to
+* John Bowler <jbowler at users.sourceforge.net>
+* Roger Nilsson [macosx support]
+
+Thanks for your work. This Repository is also used as source for the [HomeBrew](http://mxcl.github.com/homebrew/) Formula to build it.
+
 This is upslug2.
 
 upslug2 is a command line program intended to allow the upgrade of a LinkSys

--- a/README.md
+++ b/README.md
@@ -11,7 +11,16 @@ to be able to compile nowdays.
 
 Thanks for your work. This Repository is also used as source for the [HomeBrew](http://mxcl.github.com/homebrew/) Formula to build it.
 
-This is upslug2.
+To install upslug2 with homebrew simply write:
+
+```
+  $ brew install https://raw.github.com/carlesso/upslug2/master/brew_formula/upslug2.rb
+```
+
+
+-----------------------------------
+
+##This is upslug2.
 
 upslug2 is a command line program intended to allow the upgrade of a LinkSys
 NSLU2 firmware to new or different versions.  Unlike upslug and the LinkSys

--- a/brew_formula/upslug2.rb
+++ b/brew_formula/upslug2.rb
@@ -1,0 +1,28 @@
+require 'formula'
+
+class Upslug2 < Formula
+  homepage 'https://github.com/carlesso/upslug2'
+
+  url 'https://github.com/carlesso/upslug2.git', :revision => 'e3d1163d130e588f91c863b2719018cab7470e38'
+
+  head 'https://github.com/wspringer/upslug2.git'
+  version '2.11'
+
+  depends_on :autoconf
+  depends_on :automake
+  depends_on :libtool
+
+  def install
+    system "autoreconf", "-iv"
+    ENV['CPPFLAGS'] = "-I/opt/local/include"
+    ENV['LDFLAGS'] = "-L/opt/local/lib"
+    system "./configure", "--with-libpcap", "--prefix=#{prefix}"
+
+    system "make"
+    system "make install"
+  end
+
+  def test
+    system "#{sbin}/upslug2"
+  end
+end

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ(2.59)
 AC_INIT(upslug2, 12, http://sourceforge.net/projects/nslu/)
 AM_INIT_AUTOMAKE(1.9)
 AC_CONFIG_SRCDIR([config.h.in])
-AM_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 # Checks system specific stuff
 AC_CANONICAL_HOST


### PR DESCRIPTION
And should be replaced by AC_CONFIG_HEADERS

This patch is needed to compile nowdays. If you could merge it, I will release a [homebrew](http://mxcl.github.com/homebrew/) Formula to compile it, otherwise I'll change the formula tu use this fork. 

Let me know!
